### PR TITLE
Add Shot dependency to kata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ android:
   components:
     - tools
     - build-tools-23.0.2
+    - android-19
     - android-23
     - extra-android-support
     - extra-google-m2repository
@@ -18,8 +19,6 @@ android:
     - sys-img-armeabi-v7a-android-19
 
 before_script:
-  - sudo pip install --upgrade pip
-  - sudo pip install pillowcase
   - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
   - mksdcard -l sdcard 100M sdcard
   - emulator -avd test -no-audio -no-window -sdcard sdcard &
@@ -30,4 +29,4 @@ before_script:
   - adb shell input keyevent 82 &
 
 script:
-  - ./gradlew checkstyle build verifyMode screenshotTests -Pcom.android.build.threadPoolSize=1 -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xms1024m -Xmx1024m" -Dorg.gradle.daemon=false
+  - ./gradlew checkstyle build executeScreenshotTests -Pcom.android.build.threadPoolSize=1 -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xms1024m -Xmx1024m" -Dorg.gradle.daemon=false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,14 @@ buildscript {
   dependencies {
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
     classpath 'com.facebook.testing.screenshot:plugin:0.4.2'
+    classpath 'com.karumi:shot:0.1.2'
   }
 }
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.facebook.testing.screenshot'
+apply plugin: 'shot'
 
 android {
   compileSdkVersion 23
@@ -68,4 +70,8 @@ dependencies {
 
 configurations.all {
   resolutionStrategy.force 'com.android.support:support-annotations:23.0.1'
+}
+
+shot {
+  appId = 'com.karumi.screenshot'
 }


### PR DESCRIPTION
Add the [Shot plugin](https://github.com/Karumi/Shot) to the `kata-screenshot` branch 🚀 