### PR TITLE
Load android-19 in trusty environments and update shot plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ android:
   components:
     - tools
     - build-tools-23.0.2
+    - android-19
     - android-23
     - extra-android-support
     - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   dependencies {
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
     classpath 'com.facebook.testing.screenshot:plugin:0.4.2'
-    classpath 'com.karumi:shot:0.1.1'
+    classpath 'com.karumi:shot:0.1.2'
   }
 }
 


### PR DESCRIPTION
Two changes in here:

* Update the Shot library from `0.1.1` to `0.1.2`
* Load `android-19` in travis before building (it was already included in precise environments and not anymore in trusty ones)